### PR TITLE
Allow opting out from formatting

### DIFF
--- a/Scripts/rubyfmt.js
+++ b/Scripts/rubyfmt.js
@@ -15,7 +15,7 @@ const rubyfmt = (inputText) => {
     const rubyfmtPath = nova.path.expanduser(configPath);
 
     return new Process(rubyfmtPath, {
-      args: ["--"],
+      args: ["--header-opt-out", "--"],
       stdio: "pipe",
     });
   };


### PR DESCRIPTION
Add the flag `--header-opt-out` to the rubyfmt process. This is useful for opting out from automatic formatting on save by adding `# rubyfmt: false` at the top a file. For example to leave the default bundler format in Gemfile.